### PR TITLE
chore: update vlcuster chart to fix coredns issue

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: vcluster
   repository: https://charts.loft.sh
-  version: 0.15.0
-digest: sha256:6b8df46e2fddc29bb0fd8aaef848efe4a4f6e710415b58c154fec61ed4382ce9
-generated: "2023-05-02T09:44:14.226488294+01:00"
+  version: 0.16.4
+digest: sha256:7219f503be298829290bd220f9541fa3392532cf941cf7cb2c280c31a07e6212
+generated: "2023-11-03T09:37:08.067189228+05:30"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
   - name: Flanksource
 dependencies:
   - name: vcluster
-    version: ">=0.14.0"
+    version: ">=0.16.4"
     repository: https://charts.loft.sh


### PR DESCRIPTION
Related issue: https://github.com/loft-sh/vcluster/issues/1141

Some of our coredns pods are in a forever CrashLoop

```
org-99ufqu0vnxbp                 coredns-56bfc489cf-n9zkq-x-kube-system-x-org-99ufqu0vnxbp         0/1     CrashLoopBackOff   10314 (113s ago)   36d
org-km5ujf27jyjt                 coredns-56bfc489cf-vhckc-x-kube-system-x-org-km5ujf27jyjt         1/1     Running            0                  23d
org-u41iszbnkzoh                 coredns-56bfc489cf-vdzb6-x-kube-system-x-org-u41iszbnkzoh         0/1     CrashLoopBackOff   739 (115s ago)     2d14h
```