### PR TITLE
feat: increase client body buffer size

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     cert-manager.io/cluster-issuer: ingress-ca
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128m"
+    nginx.ingress.kubernetes.io/client-body-buffer-size: "128m"
 spec:
   ingressClassName: ingress-nginx
   rules:
@@ -37,6 +38,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     cert-manager.io/cluster-issuer: ingress-ca
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128m"
+    nginx.ingress.kubernetes.io/client-body-buffer-size: "128m"
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
@moshloop Proxy buffer size is for response, and client body buffer size is for client's request