### PR TITLE
feat: enable metrics port for all tenants by default

### DIFF
--- a/chart/templates/service-monitors.yaml
+++ b/chart/templates/service-monitors.yaml
@@ -18,7 +18,7 @@ metadata:
   name: mission-control-{{ .Release.Name }}-monitor
 spec:
   endpoints:
-    - port: http
+    - port: metrics
       interval: 30s
   selector:
     matchLabels:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -10,6 +10,7 @@ missionControl:
   authProvider: clerk
   clerkJWKSURL: ""
   clerkOrgID: ""
+  metricsPort: 7891
   global:
     ui:
       host: app.flanksource.com


### PR DESCRIPTION
Set metricsPort to 7891 by default in the missionControl chart configuration.
This enables the unauthenticated metrics endpoint on a dedicated port for all
tenant deployments, allowing Prometheus scraping without authentication.